### PR TITLE
fix: change color fields format to hexadecimal in CreateUserDTO and a…

### DIFF
--- a/src/main/java/co/edu/eci/pigball/user/dto/CreateUserDTO.java
+++ b/src/main/java/co/edu/eci/pigball/user/dto/CreateUserDTO.java
@@ -1,6 +1,5 @@
 package co.edu.eci.pigball.user.dto;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -36,4 +35,8 @@ public class CreateUserDTO {
     @NotBlank(message = "El centerColor es obligatorio")
     @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "El centerColor debe estar en formato hexadecimal #RRGGBB")
     private String centerColor;
+
+    @NotNull(message = "El tipo de icono es obligatorio")
+    private String iconType;
+
 }

--- a/src/main/java/co/edu/eci/pigball/user/dto/UpdateUserDTO.java
+++ b/src/main/java/co/edu/eci/pigball/user/dto/UpdateUserDTO.java
@@ -23,4 +23,6 @@ public class UpdateUserDTO {
 
     @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "El iconColor debe estar en formato hexadecimal #RRGGBB")
     private String iconColor; // Color del icono
+
+    private String iconType; // Tipo de icono (opcional)
 }

--- a/src/main/java/co/edu/eci/pigball/user/dto/UserResponseDTO.java
+++ b/src/main/java/co/edu/eci/pigball/user/dto/UserResponseDTO.java
@@ -22,4 +22,5 @@ public class UserResponseDTO {
     private String borderColor;  
     private String centerColor;
     private String iconColor;
+    private String iconType;
 }

--- a/src/main/java/co/edu/eci/pigball/user/model/User.java
+++ b/src/main/java/co/edu/eci/pigball/user/model/User.java
@@ -39,6 +39,8 @@ public class User {
 
     private String image;
 
+    private String iconType;
+
     private String borderColor;  // Color del borde
 
     private String centerColor; 

--- a/src/main/java/co/edu/eci/pigball/user/service/UserServiceImp.java
+++ b/src/main/java/co/edu/eci/pigball/user/service/UserServiceImp.java
@@ -34,6 +34,7 @@ public class UserServiceImp implements UserService {
                 .borderColor(userDTO.getBorderColor())
                 .centerColor(userDTO.getCenterColor())
                 .iconColor(userDTO.getIconColor())
+                .iconType(userDTO.getIconType())
                 .build();
 
         User savedUser = userRepository.save(user);
@@ -100,6 +101,9 @@ public class UserServiceImp implements UserService {
         if (userDTO.getIconColor() != null) {
             existingUser.setIconColor(userDTO.getIconColor());
         }
+        if (userDTO.getIconType() != null) {
+            existingUser.setIconType(userDTO.getIconType());
+        }
 
         User updatedUser = userRepository.save(existingUser);
         return convertToDTO(updatedUser);
@@ -127,6 +131,7 @@ public class UserServiceImp implements UserService {
                 .image(user.getImage())
                 .borderColor(user.getBorderColor())
                 .centerColor(user.getCenterColor())
+                .iconType(user.getIconType())
                 .iconColor(user.getIconColor())
                 .build();
     }


### PR DESCRIPTION
Main changes:

Added a new iconType field to CreateUserDTO.

Replaced the RGB class with String fields for iconColor, borderColor, and centerColor, keeping their names but changing their type.

Applied @Pattern validation to enforce the hexadecimal color format (#RRGGBB).

Updated UserResponseDTO and UserServiceImp accordingly.