### PR TITLE
feat: Limit CORS origins to front-pig-ball.vercel.app and localhost

### DIFF
--- a/src/main/java/co/edu/eci/pigball/user/controller/UserController.java
+++ b/src/main/java/co/edu/eci/pigball/user/controller/UserController.java
@@ -17,7 +17,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = {
+    "https://front-pig-ball.vercel.app",
+    "https://localhost:3000",
+    "http://localhost:3000",
+})
 @RestController
 @RequestMapping("/user")
 public class UserController {


### PR DESCRIPTION
## 🔒 CORS Configuration Update

- Restricted allowed origins to:
  - `https://front-pig-ball.vercel.app`
  - `https://localhost:3000`
  - `http://localhost:3000`
- Removed wildcard (`*`) to enhance security by only permitting trusted front-end domains.